### PR TITLE
Add abstract drivetrain class

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@
 
 > 1408H's source code for the 2024-25 "High Stakes" season of VRC.
 
-### Sponsored by Teehee Dental Works
+### Sponsored by [Teehee Dental Works](https://teehee.sg/)
+
+**1408Hyper-2024VRC-Code** was designed with portability in mind - we understand that situations can quickly change at any competition.  
+
+Our code is hot-swappable, making heavy use of **abstract classes** and **templates**
+to allow for us to rapidly change and test different pieces of code when time is of the essence.
 
 ## Included Libraries
+- Created with [`PROS` API](https://github.com/purduesigbots/pros)
+as this has better documentation
 - [**fmt**](https://fmt.dev/11.0/) for text formatting. Polyfill of C++20's `std::format` as  PROS currently doesn't support it.
 
-#### Main file at `src/main.cpp`
+#### Main file at `src/main.cpp`. To run Make, first install [ARM G++](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads).

--- a/scripts/install-arm-gcc.sh
+++ b/scripts/install-arm-gcc.sh
@@ -1,0 +1,48 @@
+# Install ARM GCC toolchain (arm-none-eabi-gcc/g++) on linux
+# can be used for CI testing or CodeQL, for final build use PROS
+# MUST BE RUN WITH SUDO
+
+set +x
+
+# Variables
+install_version = 13.3.rel1
+install_path = /usr/share/
+
+# DO NOT MODIFY BELOW THIS LINE
+
+# Remove outdated toolchain (if it exists)
+
+echo "Removing outdated Launchpad toolchain (if it exists)"
+sudo apt remove gcc-arm-none-eabi
+
+# Check if ARM GCC is already installed
+if command -v arm-none-eabi-gcc &>/dev/null; then
+    echo "arm-none-eabi-gcc is already installed. Halting script execution."
+    exit 1
+fi
+
+# Install deps
+echo "Installing deps: wget, libncurses5"
+sudo apt update
+sudo apt install wget
+sudo apt install libncurses5
+
+# Download and extract the toolchain
+sudo wget -P $install_path https://developer.arm.com/-/media/Files/downloads/gnu/$install_version/binrel/arm-gnu-toolchain-$install_version-x86_64-arm-none-eabi.tar.xz
+sudo tar -xJf /usr/share/arm-gnu-toolchain-$install_version-x86_64-arm-none-eabi.tar.xz -C $install_path
+
+install_bin_dir = $install_path/arm-gnu-toolchain-$install_version-x86_64-arm-none-eabi/bin
+echo "Extracted toolchain binaries to $install_bin_dir"
+
+# Setup symlinks
+sudo ln -s $install_bin_dir/arm-none-eabi-g++ /usr/bin/arm-none-eabi-g++
+sudo ln -s $install_bin_dir/arm-none-eabi-gcc /usr/bin/arm-none-eabi-gcc
+sudo ln -s $install_bin_dir/bin/arm-none-eabi-objcopy /usr/bin/arm-none-eabi-objcopy
+sudo ln -s $install_bin_dir/arm-none-eabi-objsize /usr/bin/arm-none-eabi-objsize
+echo "Created symlinks in /usr/bin for access to toolchain binaries"
+
+# Final version test
+arm-none-eabi-gcc --version
+arm-none-eabi-g++ --version
+
+echo "ARM GCC toolchain installation complete"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,20 +24,53 @@ string vectorToString(vector<T>& vec, string delimiter = ", ") {
 	return oss.str();
 }
 
+/// @brief Abstract drivetrain class for if you want a custom drivetrain class
 class AbstractDrivetrain {
-	public:
-
 	private:
-	
-};
-
-
-/// @brief Drivetrain class for controlling auton/driver control
-class Drivetrain {
-	private:
+	protected:
 		pros::MotorGroup left_mg;
 		pros::MotorGroup right_mg;
 		pros::Controller master;
+	public:
+		/// @brief Creates abstract drivetrain object
+		/// @param leftPorts Ports for the left motor group
+		/// @param rightPorts Ports for the right motor group
+		/// @param master Controller for driver control
+		AbstractDrivetrain(
+		  std::vector<std::int8_t>& leftPorts, 
+		  std::vector<std::int8_t>& rightPorts, 
+		  pros::controller_id_e_t master = pros::E_CONTROLLER_MASTER 
+		) : left_mg(leftPorts), right_mg(rightPorts), master(master) {
+			string consoleMsg = fmt::format("Drivetrain created with left ports: {} and right ports: {}",
+			 vectorToString(leftPorts), vectorToString(rightPorts));
+			pros::lcd::print(0, consoleMsg.c_str());
+		};
+
+		virtual ~AbstractDrivetrain() = default;
+
+		// Getters for motor groups and controller
+
+		/// @brief Gets the left motor group
+		pros::MotorGroup& getLeftMotorGroup() {
+			return left_mg;
+		}
+
+		/// @brief Gets the right motor group
+		pros::MotorGroup& getRightMotorGroup() {
+			return right_mg;
+		}
+
+		/// @brief Gets the controller
+		pros::Controller& getController() {
+			return master;
+		}
+
+		virtual void opControl() = 0;
+};
+
+/// @brief Drivetrain class for controlling auton/driver control
+class Drivetrain : public AbstractDrivetrain {
+	private:
 	public:
 		/// @brief Enum for different driver control modes
 		enum OpControlMode {
@@ -62,29 +95,7 @@ class Drivetrain {
 		  Drivetrain::OpControlMode opControlMode = Drivetrain::OpControlMode::ARCADE,
 		  int opControlSpeed = 1, 
 		  int autonSpeed = 100
-		  ) : left_mg(leftPorts), right_mg(rightPorts), master(master), opControlMode(opControlMode), autonSpeed(autonSpeed), opControlSpeed(opControlSpeed) {
-
-			string consoleMsg = fmt::format("Drivetrain created with left ports: {} and right ports: {}",
-			 vectorToString(leftPorts), vectorToString(rightPorts));
-			pros::lcd::print(0, consoleMsg.c_str());
-		};
-
-		// Getters for motor groups and controller
-
-		/// @brief Gets the left motor group
-		pros::MotorGroup& getLeftMotorGroup() {
-			return left_mg;
-		}
-
-		/// @brief Gets the right motor group
-		pros::MotorGroup& getRightMotorGroup() {
-			return right_mg;
-		}
-
-		/// @brief Gets the controller
-		pros::Controller& getController() {
-			return master;
-		}
+		  ) : AbstractDrivetrain(leftPorts, rightPorts, master), opControlMode(opControlMode), autonSpeed(autonSpeed), opControlSpeed(opControlSpeed) {};
 
 		/// @brief Runs the default drive mode specified in opControlMode 
 		/// (recommended to be used instead of directly calling the control functions)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,9 +28,8 @@ class AbstractDrivetrain {
 	public:
 
 	private:
-	
-}
 
+}
 
 /// @brief Drivetrain class for controlling auton/driver control
 class Drivetrain {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,14 @@ string vectorToString(vector<T>& vec, string delimiter = ", ") {
 	return oss.str();
 }
 
+class AbstractDrivetrain {
+	public:
+
+	private:
+	
+}
+
+
 /// @brief Drivetrain class for controlling auton/driver control
 class Drivetrain {
 	private:


### PR DESCRIPTION
Creating a new abstract drivetrain class for other drivetrains to derive from if we would like to create a different implementation of the drivetrain that performs certain functions differently.