### PR TITLE
Refactor classes & AbstractMech

### DIFF
--- a/include/options.h
+++ b/include/options.h
@@ -17,7 +17,7 @@
 #define LIFT_MECH_PORT 'A'
 
 // Motor ports for the conveyer
-#define CONVEYER_PORTS {11, 19}
+#define CONVEYER_PORTS {11, -1}
 
 // Motor ports for the conveyer
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -358,6 +358,9 @@ namespace hyper {
 			}
 	}; // class MogoMech
 
+	// Fix circular dependency
+	class Chassis;
+
 	/// @brief Main auton class
 	class Auton {
 		private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,22 +86,22 @@ namespace hyper {
 	}; // class AbstractChassis
 
 	/// @brief Class for components of the chassis to derive from
-	class ChassisComponent {
+	class AbstractComponent {
 		private:
 		protected:
 			AbstractChassis* chassis;
 
 			pros::Controller* master;
 		public:
-			/// @brief Args for ChassisComponent object
+			/// @brief Args for AbstractComponent object
 			/// @param chassis AbstractChassis derived object to be used for the component
-			struct ChassisComponentArgs {
+			struct AbstractComponentArgs {
 				AbstractChassis* chassis;
 			};
 
-			/// @brief Creates ChassisComponent object
-			/// @param args Args ChassisComponent object (check args struct for more info)
-			ChassisComponent(ChassisComponentArgs args) : 
+			/// @brief Creates AbstractComponent object
+			/// @param args Args AbstractComponent object (check args struct for more info)
+			AbstractComponent(AbstractComponentArgs args) : 
 			chassis(args.chassis),
 			master(&args.chassis->getController()) {
 				// :) u know what this does
@@ -114,7 +114,9 @@ namespace hyper {
 				return *chassis;
 			}
 
-			virtual ~ChassisComponent() = default;
+			virtual void opControl() = 0;
+
+			virtual ~AbstractComponent() = default;
 	}; // class ChassisComponent
 
 	/// @brief Class for a toggle on the controller
@@ -182,7 +184,7 @@ namespace hyper {
 			}
 	}; // class Toggle
 
-	class Conveyer : public ChassisComponent {
+	class Conveyer : public AbstractComponent {
 		private:
 			pros::MotorGroup conveyerMotors;
 			//bool conveyerEngaged = false;
@@ -200,8 +202,11 @@ namespace hyper {
 			}*/
 		protected:
 		public:
+			/// @brief Args for conveyer object
+			/// @param abstractComponentArgs Args for AbstractComponent object
+			/// @param conveyerPorts Vector of ports for conveyer motors
 			struct ConveyerArgs {
-				ChassisComponentArgs chassisComponentArgs;
+				AbstractComponentArgs abstractComponentArgs;
 				vector<std::int8_t> conveyerPorts;
 			};
 
@@ -219,7 +224,7 @@ namespace hyper {
 			Buttons btns = {};
 
 			Conveyer(ConveyerArgs args) :
-				ChassisComponent(args.chassisComponentArgs),
+				AbstractComponent(args.abstractComponentArgs),
 				conveyerMotors(args.conveyerPorts) {};
 
 			void move(bool on, bool directionForward = true) {
@@ -234,7 +239,7 @@ namespace hyper {
 				}
 			}
 
-			void opControl() {
+			void opControl() override {
 				if (master->get_digital(btns.on)) {
 					move(true);
 				} else if (master->get_digital(btns.off)) {
@@ -245,7 +250,7 @@ namespace hyper {
 			}
 	}; // class Conveyer
 
-	class LiftMech : public ChassisComponent {
+	class LiftMech : public AbstractComponent {
 		private:
 			pros::adi::DigitalOut piston;
 			//bool engaged = false;
@@ -265,9 +270,9 @@ namespace hyper {
 		protected:
 		public:
 			/// @brief Args for mogo mech object
-			/// @param chassisComponentArgs Args for ChassisComponent object
+			/// @param abstractComponentArgs Args for AbstractComponent object
 			struct LiftMechArgs {
-				ChassisComponentArgs chassisComponentArgs;
+				AbstractComponentArgs abstractComponentArgs;
 				char pistonPort;
 			};
 
@@ -284,10 +289,10 @@ namespace hyper {
 			/// @brief Creates mogo mech object
 			/// @param args Args for MogoMech object (check args struct for more info)
 			LiftMech(LiftMechArgs args) : 
-				ChassisComponent(args.chassisComponentArgs),
+				AbstractComponent(args.abstractComponentArgs),
 				piston(args.pistonPort) {};
 
-			void opControl () {
+			void opControl () override {
 				// Perform the actuation if this is the button has JUST been pressed
 				if (master->get_digital(btns.on)) {
 					piston.set_value(true);
@@ -303,7 +308,7 @@ namespace hyper {
 			}
 	}; // class LiftMech
 
-	class MogoMech : public ChassisComponent {
+	class MogoMech : public AbstractComponent {
 		private:
 			pros::adi::DigitalOut piston;
 			bool engaged = false;
@@ -325,19 +330,19 @@ namespace hyper {
 			pros::controller_digital_e_t btn = pros::E_CONTROLLER_DIGITAL_A;
 
 			/// @brief Args for mogo mech object
-			/// @param chassisComponentArgs Args for ChassisComponent object
+			/// @param abstractComponentArgs Args for AbstractComponent object
 			struct MogoMechArgs {
-				ChassisComponentArgs chassisComponentArgs;
+				AbstractComponentArgs abstractComponentArgs;
 				char pistonPort;
 			};
 
 			/// @brief Creates mogo mech object
 			/// @param args Args for MogoMech object (check args struct for more info)
 			MogoMech(MogoMechArgs args) : 
-				ChassisComponent(args.chassisComponentArgs),
+				AbstractComponent(args.abstractComponentArgs),
 				piston(args.pistonPort) {};
 
-			void opControl () {
+			void opControl () override {
 				// Perform the actuation if this is the button has JUST been pressed
 				if (master->get_digital(btn)) {
 					pneumaticActuation();
@@ -411,7 +416,7 @@ namespace hyper {
 
 			MogoMech mogoMech;
 			LiftMech liftMech;
-			
+
 			Conveyer conveyer;
 
 			/// @brief Creates chassis object

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,8 @@
 
 // TODO: Refactor ChassisComponent into abstract class, then
 // iterate over array of components running opControl for each.
-// (Auton will no longer be ChassisComponent)
+// easier than manually calling each component's opControl/constructor
+// NO LONGER ISSUE FOR AUTON CUZ IT IS NOW NOT DERIVING FROM CHASSISCOMPONENT
 
 // TODO: Create swith class for controls with 2 states
 
@@ -357,16 +358,16 @@ namespace hyper {
 	}; // class MogoMech
 
 	/// @brief Main auton class
-	class Auton{
+	class Auton {
 		private:
-			AbstractChassis* chassis;
+			Chassis* chassis;
 		protected:
 		public:
 			/// @brief Args for auton object
 			/// @param chassisComponentArgs Args for ChassisComponent object
 			/// @param speed Speed for auton control
 			struct AutonArgs {
-				AbstractChassis* chassis;
+				Chassis* chassis;
 				int speed = 100;
 			};
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -211,8 +211,8 @@ namespace hyper {
 			};
 
 			struct Speeds {
-				int fwd = 200;
-				int back = -200;
+				int fwd = 600;
+				int back = -600;
 			};
 
 			struct Buttons {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -357,14 +357,16 @@ namespace hyper {
 	}; // class MogoMech
 
 	/// @brief Main auton class
-	class Auton : public ChassisComponent {
+	class Auton{
 		private:
+			AbstractChassis* chassis;
+		protected:
 		public:
 			/// @brief Args for auton object
 			/// @param chassisComponentArgs Args for ChassisComponent object
 			/// @param speed Speed for auton control
 			struct AutonArgs {
-				ChassisComponentArgs chassisComponentArgs;
+				AbstractChassis* chassis;
 				int speed = 100;
 			};
 
@@ -373,7 +375,7 @@ namespace hyper {
 			/// @brief Creates auton object
 			/// @param args Args for ChassisComponent object (check args struct for more info)
 			Auton(AutonArgs args) : 
-				ChassisComponent(args.chassisComponentArgs), speed(args.speed) {};
+				chassis(args.chassis), speed(args.speed) {};
 
 			void go() {
 				// TODO: Implement auton

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,18 +11,7 @@
 // currently using legacy toggles (not using Toggle class):
 // liftmech, conveyer, mogomech
 
-// TODO: Refactor ChassisComponent into abstract class, then
-// iterate over array of components running opControl for each.
-// easier than manually calling each component's opControl/constructor
-// NO LONGER ISSUE FOR AUTON CUZ IT IS NOW NOT DERIVING FROM CHASSISCOMPONENT
-
-// TODO: Refactor static options (variables with no need to init)
-// into new struct for each class so no need to redeclare.
-// THIS HAS A NEW CONSEQUENCE (SEE BELOW)
-
-// TODO: Basic structs in each class for buttons/speeds (mainly for components)
-
-// so much DRY violations >:((((( need more classes!!!!!
+// TODO: so much DRY violations >:((((( need more classes!!!!! (pneumaticcomponent)
 
 /// @brief Hyper namespace for all custom classes and functions
 namespace hyper {
@@ -118,6 +107,40 @@ namespace hyper {
 
 			virtual ~AbstractComponent() = default;
 	}; // class ChassisComponent
+
+	class AbstractMech : public AbstractComponent {
+		private:
+		protected:
+			pros::adi::DigitalOut piston;
+		public:
+			/// @brief Args for abstract mech object
+			/// @param abstractComponentArgs Args for AbstractComponent object
+			/// @param pistonPort Port for piston
+			struct AbstractMechArgs {
+				AbstractComponentArgs abstractComponentArgs;
+				char pistonPort;
+			};
+
+			/// @brief Creates abstract mech object
+			/// @param args Args for abstract mech object (check args struct for more info)
+			AbstractMech(AbstractMechArgs args) : 
+				AbstractComponent(args.abstractComponentArgs),
+				piston(args.pistonPort) {};
+
+			/// @brief Sets actuation value of piston
+			/// @param value Value to set the piston to
+			void actuate(bool value) {
+				piston.set_value(value);
+			}
+
+			/// @brief Gets the piston object
+			/// @return PROS ADI DigitalOut object for piston
+			pros::adi::DigitalOut& getPiston() {
+				return piston;
+			}
+
+			virtual ~AbstractMech() = default;
+	}; // class AbstractMech
 
 	/// @brief Class for a toggle on the controller
 	class Toggle {
@@ -314,7 +337,7 @@ namespace hyper {
 			bool engaged = false;
 			bool lastPressed = false;
 
-			void pneumaticActuation() {
+			void processPress() {
 				if (!lastPressed) {
 					//pros::lcd::set_text(1, "A ENGAGED NOT PRESSED");
 					engaged = !engaged;
@@ -345,7 +368,7 @@ namespace hyper {
 			void opControl () override {
 				// Perform the actuation if this is the button has JUST been pressed
 				if (master->get_digital(btn)) {
-					pneumaticActuation();
+					processPress();
 					lastPressed = true;
 					//pros::lcd::set_text(1, "L1 pressed");
 				} else {
@@ -370,7 +393,7 @@ namespace hyper {
 			int speed = 100;
 
 			/// @brief Creates auton object
-			/// @param args Args for ChassisComponent object (check args struct for more info)
+			/// @param chassis Pointer to chassis object
 			Auton(Chassis* chassis) : 
 				chassis(chassis) {};
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -273,9 +273,8 @@ namespace hyper {
 			}
 	}; // class Conveyer
 
-	class LiftMech : public AbstractComponent {
+	class LiftMech : public AbstractMech {
 		private:
-			pros::adi::DigitalOut piston;
 			//bool engaged = false;
 			//bool lastPressed = false;
 
@@ -293,10 +292,9 @@ namespace hyper {
 		protected:
 		public:
 			/// @brief Args for mogo mech object
-			/// @param abstractComponentArgs Args for AbstractComponent object
+			/// @param abstractMechArgs Args for AbstractMech object
 			struct LiftMechArgs {
-				AbstractComponentArgs abstractComponentArgs;
-				char pistonPort;
+				AbstractMechArgs abstractMechArgs;
 			};
 
 			/// @brief Struct for buttons for lift mech object
@@ -312,9 +310,9 @@ namespace hyper {
 			/// @brief Creates mogo mech object
 			/// @param args Args for MogoMech object (check args struct for more info)
 			LiftMech(LiftMechArgs args) : 
-				AbstractComponent(args.abstractComponentArgs),
-				piston(args.pistonPort) {};
+				AbstractMech(args.abstractMechArgs) {};
 
+			/// @brief Runs every loop to check if the button has been pressed
 			void opControl () override {
 				// Perform the actuation if this is the button has JUST been pressed
 				if (master->get_digital(btns.on)) {
@@ -324,16 +322,10 @@ namespace hyper {
 					piston.set_value(false);
 				}
 			}
-
-			/// @brief Gets the piston object 
-			pros::adi::DigitalOut& getPiston() {
-				return piston;
-			}
 	}; // class LiftMech
 
-	class MogoMech : public AbstractComponent {
+	class MogoMech : public AbstractMech {
 		private:
-			pros::adi::DigitalOut piston;
 			bool engaged = false;
 			bool lastPressed = false;
 
@@ -353,18 +345,17 @@ namespace hyper {
 			pros::controller_digital_e_t btn = pros::E_CONTROLLER_DIGITAL_A;
 
 			/// @brief Args for mogo mech object
-			/// @param abstractComponentArgs Args for AbstractComponent object
+			/// @param abstractMechArgs Args for AbstractMech object
 			struct MogoMechArgs {
-				AbstractComponentArgs abstractComponentArgs;
-				char pistonPort;
+				AbstractMechArgs abstractMechArgs;
 			};
 
 			/// @brief Creates mogo mech object
 			/// @param args Args for MogoMech object (check args struct for more info)
 			MogoMech(MogoMechArgs args) : 
-				AbstractComponent(args.abstractComponentArgs),
-				piston(args.pistonPort) {};
+				AbstractMech(args.abstractMechArgs) {};
 
+			/// @brief Runs every loop to check if the button has been pressed
 			void opControl () override {
 				// Perform the actuation if this is the button has JUST been pressed
 				if (master->get_digital(btn)) {
@@ -374,10 +365,6 @@ namespace hyper {
 				} else {
 					lastPressed = false;
 				}
-			}
-
-			pros::adi::DigitalOut& getPiston() {
-				return piston;
 			}
 	}; // class MogoMech
 


### PR DESCRIPTION
This PR refactors many classes to be more concise and simple while also reducing space complexity for our device.

**Args refactoring**

1. Currently, classes have their `Args` struct with lots of default arguments. The default args must have their corresponding properties repeated in their own declarations. However, this is mostly redundant as these optional default args are rarely ever needed.
2. So, we have solved this by removing these redundant args from the struct and just putting the values into each corresponding property of these classes directly.

- We also tried a solution whereby we had a` StaticOptions` struct which included all properties and args like this. However, this is clunky to implement and modify and therefore not in line with our "quick-switching" principles of this project. We will only be leaving this implementation in one class - the Toggle class.

**Abstract classes**

1. We have made `ChassisComponent` into `AbstractComponent`, which now has a required function of `opControl`. Auton no longer derives from `AbstractComponent`.
2. The new `AbstractMech` class has also been added, containing many common properties/functions used in pneumatic mechanisms. All new pneumatics will derive from this, with existing classes already migrated.

*Additional miscellaneous changes e.g. bugfixes/port changes*

As always, we hope we have improved the competitive readiness of the robot in preparation for upcoming preparations and improved the code as a whole.

_**1408H**yper_
_Software Engineering Department_